### PR TITLE
ci: add release artifacts workflow

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,0 +1,45 @@
+name: Build and upload release artifacts
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build artifacts
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        target: [x86_64-unknown-linux-gnu, x86_64-pc-windows-msvc]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install target
+        run: |
+          rustup target add ${{ matrix.target }}
+
+      - name: Build release
+        run: |
+          cargo build --manifest-path ./crates/ark-wallet-cli/Cargo.toml --release --target ${ { matrix.target } }
+
+      - name: Package artifact
+        run: |
+          mkdir -p dist
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            powershell -Command "Compress-Archive -Path target/${{ matrix.target }}/release/ark-wallet.exe -DestinationPath dist/ark-wallet-${{ github.ref_name }}-windows-x86_64.zip"
+          else
+            tar -czf dist/ark-wallet-${{ github.ref_name }}-linux-x86_64.tar.gz -C target/${{ matrix.target }}/release ark-wallet
+          fi
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a workflow to build and upload Linux + Windows artifacts when a Release is published.