### PR TITLE
chore: fix formatting + clippy; add AES-GCM envelope helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# ArkProtocol-Astra
+
+## AES-256-GCM Envelope Helpers
+
+- Added `hot_prepare_envelope` and `hot_decrypt_envelope` for two-phase hot signing.
+- Sensitive buffers (keys, nonces) are zeroized using the `zeroize` crate for memory safety.
+- Usage: Prepare an envelope with `hot_prepare_envelope`, decrypt with `hot_decrypt_envelope`.
+- Next: CLI subcommands for prepare/broadcast (planned).
+
+
+Notes
+
+This repository contains a CLI wallet (`crates/ark-wallet-cli`) used for demonstration and tooling. The AES-GCM helpers provide a secure envelope format for transferring signed payloads between offline (hot-sign) and online (broadcaster) devices.


### PR DESCRIPTION
Summary: Fixed formatting and Clippy warnings, added AES-256-GCM envelope helpers (hot_prepare_envelope, hot_decrypt_envelope) with zeroization. CI passing. Next steps: CLI integration and further docs.